### PR TITLE
getBalance returns a String

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -347,7 +347,7 @@ export declare class Eth {
   currentProvider: Provider
   estimateGas(tx: Tx, callback?: Callback<number>): Promise<number>
   getAccounts(cb?: Callback<Array<string>>): Promise<Array<string>>
-  getBalance(address: string, defaultBlock?: BlockType, cb?: Callback<number>): Promise<number>
+  getBalance(address: string, defaultBlock?: BlockType, cb?: Callback<number>): Promise<string>
   getBlock(number: BlockType, returnTransactionObjects?: boolean, cb?: Callback<Block>): Promise<Block>
   getBlockNumber(callback?: Callback<number>): Promise<number>
   getBlockTransactionCount(number: BlockType | string, cb?: Callback<number>): Promise<number>


### PR DESCRIPTION
As defined [in the docs](http://web3js.readthedocs.io/en/1.0/web3-eth.html?highlight=getBalance#getbalance), getBalance returns a Promise that resolves to a string.